### PR TITLE
Support esformatter -p and -c command line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,22 @@ To format just one block of code select it on visual mode and execute
 
 To make it easier you can create a mapping on your `.vimrc` file like:
 
-```js
+```VimL
 " will run esformatter after pressing <leader> followed by the 'e' and 's' keys
 nnoremap <silent> <leader>es :Esformatter<CR>
 vnoremap <silent> <leader>es :EsformatterVisual<CR>
+```
+
+To specify a style preset in `.vimrc` (for example, jQuery):
+
+```VimL
+let g:esformatter_preset = 'jQuery'
+```
+
+To specify an `esformatter` configuration file:
+
+```VimL
+let g:esformatter_config = '/path/to/config.json'
 ```
 
 

--- a/plugin/esformatter.vim
+++ b/plugin/esformatter.vim
@@ -19,6 +19,17 @@ endif
 
 let loaded_esformatter = 1
 
+function! s:EsformatterCommand()
+  let options = ''
+  if exists('g:esformatter_preset')
+      let options .= '-p ' . shellescape(g:esformatter_preset)
+  endif
+  if exists('g:esformatter_config')
+      let options .= '-c ' . shellescape(g:esformatter_config)
+  endif
+  return ['esformatter', options]
+endfunction
+
 function! s:EsformatterNormal()
   " store current cursor position and change the working directory
   let win_view = winsaveview()
@@ -27,7 +38,7 @@ function! s:EsformatterNormal()
   execute ':lcd' . file_wd
 
   " pass whole buffer content to esformatter
-  let output = system('esformatter', join(getline(1,'$'), "\n"))
+  let output = system(join(s:EsformatterCommand(), ' '), join(getline(1,'$'), "\n"))
 
   if v:shell_error
     echom "Error while executing esformatter! no changes made."
@@ -68,7 +79,7 @@ function! s:EsformatterVisual() range
     let restore_last_line = 1
   endif
 
-  let output = system('esformatter', join(input, "\n"))
+  let output = system(join(s:EsformatterCommand(), ' '), join(input, "\n"))
 
   if v:shell_error
     echom 'Error while executing esformatter! no changes made.'


### PR DESCRIPTION
I'm a vimscript n00b, so this might be covered or supported somewhere already, but I didn't see a way to configure the VIM plugin to use a particular preset or config, so I hacked in support for it. Here it is, if you're interested.

It gives you two configuration variables to use in .vimrc: `g:esformatter_preset` and `g:esformatter_config`, and it just passes them into the `system()` call in the VIM plugin.
