### PR TITLE
Enable restoring visual selection using gv

### DIFF
--- a/plugin/esformatter.vim
+++ b/plugin/esformatter.vim
@@ -88,9 +88,15 @@ function! s:EsformatterVisual() range
 
     " add new lines to the buffer
     call append(range_start - 1, new_lines)
+
+    " Clean up: restore previous cursor position
+    call winrestview(win_view)
+    " recreate the visual selection and cancel it, so that the formatted code
+    " can be reselected using gv
+    execute "normal! V" . (len(new_lines)-1) . "j\<esc>"
   endif
 
-  " Clean up: restore previous cursor position and working directory
+  " Clean up: restore working directory
   call winrestview(win_view)
   execute ':lcd' . current_wd
 endfunction

--- a/plugin/esformatter.vim
+++ b/plugin/esformatter.vim
@@ -97,7 +97,6 @@ function! s:EsformatterVisual() range
   endif
 
   " Clean up: restore working directory
-  call winrestview(win_view)
   execute ':lcd' . current_wd
 endfunction
 


### PR DESCRIPTION
After the lines are formatted using EsformatterVisual command, visual selection could not be restored using gv command (perhaps because it was deleted by gvd on line 78). This change restores visual selection over inserted lines and cancels it, so that gv command will select all formatted (and inserted) lines.
