### PR TITLE
Add esformatter_autosave option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ nnoremap <silent> <leader>es :Esformatter<CR>
 vnoremap <silent> <leader>es :EsformatterVisual<CR>
 ```
 
+To enable auto-format on save:
+
+```vim
+let g:esformatter_autosave = 1
+```
 
 ## License
 

--- a/doc/esformatter.txt
+++ b/doc/esformatter.txt
@@ -16,6 +16,12 @@ nnoremap <silent> <leader>es :Esformatter<CR>
 vnoremap <silent> <leader>es :EsformatterVisual<CR>
 ```
 
+To enable auto-format on save:
+
+```vim
+let g:esformatter_autosave = 1
+```
+
 ===============================================================================
 REPOSITORY
 

--- a/plugin/esformatter.vim
+++ b/plugin/esformatter.vim
@@ -17,6 +17,14 @@ if !exists('g:esformatter_debug') && (exists('loaded_esformatter') || &cp)
   finish
 endif
 
+if !exists('g:esformatter_autosave')
+    let g:esformatter_autosave = 0
+endif
+
+if g:esformatter_autosave
+    autocmd BufWritePre *.js,*.jsx,*.mjs :Esformatter
+endif
+
 let loaded_esformatter = 1
 
 function! s:EsformatterNormal()


### PR DESCRIPTION
I just switched to ESFormatter and I usually like to have my formatter run automagically on save, so I don't have to think about it. The `esformatter_autosave` flag to enable it to call `:Esformatter` on save.
